### PR TITLE
Feature/lifecycle-hooks – Add optional JavaScript callbacks for every major Voy operation

### DIFF
--- a/src/wasm/voy.rs
+++ b/src/wasm/voy.rs
@@ -4,9 +4,6 @@ use crate::{engine, Neighbor, NumberOfResult, Query, Resource, SearchResult, Ser
 use js_sys::{Function, Object, Reflect};
 use wasm_bindgen::prelude::*;
 
-// ──────────────── Lifecycle‑hook support ───────────────────────────────
-/// Optional callbacks that JavaScript can provide. Every field is an
-/// optional `Function`; when present it is invoked at the matching stage.
 pub struct Options {
     pub on_init: Option<Function>,
     pub on_index: Option<Function>,
@@ -50,8 +47,7 @@ pub struct Voy {
 
 #[wasm_bindgen]
 impl Voy {
-    /// Construct a new Voy instance with an optional Resource to pre‑index
-    /// and an optional `options` object that may contain lifecycle callbacks.
+
     #[wasm_bindgen(constructor)]
     pub fn new(resource: Option<Resource>, options: Option<Object>) -> Voy {
         set_panic_hook();
@@ -67,7 +63,6 @@ impl Voy {
         Voy { index, options: opts }
     }
 
-    // ────────────── serialization helpers ────────────────────────────
     pub fn serialize(&self) -> SerializedIndex {
         if let Some(cb) = self.options.as_ref().and_then(|o| o.on_serialize.as_ref()) {
             cb.call0(&JsValue::UNDEFINED).ok();
@@ -87,7 +82,6 @@ impl Voy {
         Voy { index, options: opts }
     }
 
-    // ─────────────── mutating operations ─────────────────────────────
     pub fn index(&mut self, resource: Resource) {
         self.index = engine::index(resource).unwrap();
         if let Some(cb) = self.options.as_ref().and_then(|o| o.on_index.as_ref()) {
@@ -116,7 +110,6 @@ impl Voy {
         }
     }
 
-    // ─────────────── queries & metrics ───────────────────────────────
     pub fn search(&self, query: Query, k: NumberOfResult) -> SearchResult {
         let q: engine::Query = engine::Query::Embeddings(query);
         let neighbors_raw = engine::search(&self.index, &q, k).unwrap();
@@ -132,7 +125,6 @@ impl Voy {
         SearchResult { neighbors }
     }
 
-    /// Return the current number of embeddings stored.
     pub fn size(&self) -> usize {
         engine::size(&self.index)
     }

--- a/src/wasm/voy.rs
+++ b/src/wasm/voy.rs
@@ -1,68 +1,138 @@
 use crate::utils::set_panic_hook;
 use crate::{engine, Neighbor, NumberOfResult, Query, Resource, SearchResult, SerializedIndex};
 
+use js_sys::{Function, Object, Reflect};
 use wasm_bindgen::prelude::*;
+
+// ──────────────── Lifecycle‑hook support ───────────────────────────────
+/// Optional callbacks that JavaScript can provide. Every field is an
+/// optional `Function`; when present it is invoked at the matching stage.
+pub struct Options {
+    pub on_init: Option<Function>,
+    pub on_index: Option<Function>,
+    pub on_add: Option<Function>,
+    pub on_remove: Option<Function>,
+    pub on_search: Option<Function>,
+    pub on_clear: Option<Function>,
+    pub on_serialize: Option<Function>,
+    pub on_deserialize: Option<Function>,
+}
+
+/// Convert a JS object (the `options` arg to the constructor / deserialize)
+/// into our strongly‑typed `Options` struct. Any property that cannot be
+/// down‑cast to `Function` is ignored.
+fn reify(js_options: Option<Object>) -> Option<Options> {
+    let get_fn = |name: &str, obj: &Object| -> Option<Function> {
+        match Reflect::get(obj, &JsValue::from_str(name)) {
+            Ok(cb) if cb.is_function() => cb.dyn_into::<Function>().ok(),
+            _ => None,
+        }
+    };
+
+    js_options.map(|obj| Options {
+        on_init:        get_fn("onInit",        &obj),
+        on_index:       get_fn("onIndex",       &obj),
+        on_add:         get_fn("onAdd",         &obj),
+        on_remove:      get_fn("onRemove",      &obj),
+        on_search:      get_fn("onSearch",      &obj),
+        on_clear:       get_fn("onClear",       &obj),
+        on_serialize:   get_fn("onSerialize",   &obj),
+        on_deserialize: get_fn("onDeserialize", &obj),
+    })
+}
+// ───────────────────────────────────────────────────────────────────────
 
 #[wasm_bindgen]
 pub struct Voy {
-    index: engine::Index,
+    index:   engine::Index,
+    options: Option<Options>,
 }
 
 #[wasm_bindgen]
 impl Voy {
+    /// Construct a new Voy instance with an optional Resource to pre‑index
+    /// and an optional `options` object that may contain lifecycle callbacks.
     #[wasm_bindgen(constructor)]
-    pub fn new(resource: Option<Resource>) -> Voy {
+    pub fn new(resource: Option<Resource>, options: Option<Object>) -> Voy {
         set_panic_hook();
 
-        let resource: Resource = match resource {
-            Some(res) => res,
-            _ => Resource { embeddings: vec![] },
-        };
-        let index = engine::index(resource).unwrap();
-        Voy { index }
+        let resource = resource.unwrap_or(Resource { embeddings: vec![] });
+        let index = engine::index(resource).expect("index build failed");
+        let opts  = reify(options);
+
+        if let Some(cb) = opts.as_ref().and_then(|o| o.on_init.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
+
+        Voy { index, options: opts }
     }
 
+    // ────────────── serialization helpers ────────────────────────────
     pub fn serialize(&self) -> SerializedIndex {
+        if let Some(cb) = self.options.as_ref().and_then(|o| o.on_serialize.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
         serde_json::to_string(&self.index).unwrap()
     }
 
-    pub fn deserialize(serialized_index: SerializedIndex) -> Voy {
+    #[wasm_bindgen(js_name = "deserialize")]
+    pub fn deserialize_js(serialized_index: SerializedIndex, options: Option<Object>) -> Voy {
         let index: engine::Index = serde_json::from_str(&serialized_index).unwrap();
-        Voy { index }
+        let opts = reify(options);
+
+        if let Some(cb) = opts.as_ref().and_then(|o| o.on_deserialize.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
+
+        Voy { index, options: opts }
     }
 
+    // ─────────────── mutating operations ─────────────────────────────
     pub fn index(&mut self, resource: Resource) {
-        let index = engine::index(resource).unwrap();
-        self.index = index
-    }
-
-    pub fn search(&self, query: Query, k: NumberOfResult) -> SearchResult {
-        let query: engine::Query = engine::Query::Embeddings(query);
-        let neighbors = engine::search(&self.index, &query, k).unwrap();
-        let neighbors: Vec<Neighbor> = neighbors
-            .into_iter()
-            .map(|x| Neighbor {
-                id: x.id,
-                title: x.title,
-                url: x.url,
-            })
-            .collect();
-
-        SearchResult { neighbors }
+        self.index = engine::index(resource).unwrap();
+        if let Some(cb) = self.options.as_ref().and_then(|o| o.on_index.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
     }
 
     pub fn add(&mut self, resource: Resource) {
         engine::add(&mut self.index, &resource);
+        if let Some(cb) = self.options.as_ref().and_then(|o| o.on_add.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
     }
 
     pub fn remove(&mut self, resource: Resource) {
         engine::remove(&mut self.index, &resource);
+        if let Some(cb) = self.options.as_ref().and_then(|o| o.on_remove.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
     }
 
     pub fn clear(&mut self) {
         engine::clear(&mut self.index);
+        if let Some(cb) = self.options.as_ref().and_then(|o| o.on_clear.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
     }
 
+    // ─────────────── queries & metrics ───────────────────────────────
+    pub fn search(&self, query: Query, k: NumberOfResult) -> SearchResult {
+        let q: engine::Query = engine::Query::Embeddings(query);
+        let neighbors_raw = engine::search(&self.index, &q, k).unwrap();
+        let neighbors: Vec<Neighbor> = neighbors_raw
+            .into_iter()
+            .map(|n| Neighbor { id: n.id, title: n.title, url: n.url })
+            .collect();
+
+        if let Some(cb) = self.options.as_ref().and_then(|o| o.on_search.as_ref()) {
+            cb.call0(&JsValue::UNDEFINED).ok();
+        }
+
+        SearchResult { neighbors }
+    }
+
+    /// Return the current number of embeddings stored.
     pub fn size(&self) -> usize {
         engine::size(&self.index)
     }

--- a/src/wasm/voy.rs
+++ b/src/wasm/voy.rs
@@ -37,7 +37,6 @@ fn reify(js_options: Option<Object>) -> Option<Options> {
         on_deserialize: get_fn("onDeserialize", &obj),
     })
 }
-// ───────────────────────────────────────────────────────────────────────
 
 #[wasm_bindgen]
 pub struct Voy {


### PR DESCRIPTION
### Why  

Voy’s core API is minimal and fast, but integrators often need to **observe** what the index is doing (for logging, metrics, progress bars, custom persistence, etc.) without forking the library.  
This PR introduces an _opt-in_ “lifecycle hooks” mechanism that lets host JavaScript receive a callback whenever key events occur:

* construction / initialization  
* (re)indexing a new resource set  
* mutation (`add`, `remove`, `clear`)  
* search queries  
* serialization / deserialization  

No behavioural change occurs unless hooks are supplied.

---

### What’s inside  

1. **`Options` struct** in Rust containing eight `Option<Function>` fields.  
2. **`reify()` helper** – converts an optional JS object into `Options`.  
3. **New `options` field** on the `Voy` struct.  
4. **Constructor & `deserialize`** now accept `options?: object`.  
5. Hook invocation (`callback.call0(undefined)`) added to:
   * `new()`  → `onInit`
   * `index()` → `onIndex`
   * `add()`   → `onAdd`
   * `remove()`→ `onRemove`
   * `clear()` → `onClear`
   * `search()`→ `onSearch`
   * `serialize()`  → `onSerialize`
   * `deserialize()`→ `onDeserialize`
6. **No regression:** existing signatures preserved when `options` is omitted; performance impact is a single option-check per call.

---

### Usage example (JS)

```js
import init, { Voy } from "voy";

await init();                       // WASM boot
const voy = new Voy(undefined, {
  onInit:      () => console.log("Voy ready"),
  onAdd:       () => console.log("record added"),
  onSerialize: () => console.time("serialize"),
  onDeserialize:() => console.log("index loaded")
});

voy.add({ embeddings: [ /* … */ ] });
const blob = voy.serialize();       // console.time logged